### PR TITLE
Add support for Imenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Upcoming
+
+* Add support for Imenu (Steven Rémot, 2015-10-21T18:45:17 2015+02:00)
+
 # 0.2.1
 
 * Adapt README and code to the new repsoitory (Ivan Enderlin, Julien Bianchi, Steven Rémot)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Moreover, Hoa aims at being a bridge between industrial and research worlds.
 This repository contains tools for the PP grammar description language from
 [`Hoa\Compiler`](http://central.hoa-project.net/Resource/Library/Compiler).
 
-It provides a major mode for editing PP grammars that has syntax
-coloration and auto-indentation.
+It provides a major mode for editing PP grammars with the following features:
+
+- syntax coloration
+- auto-indentation
+- Imenu support
 
 ![PP Major mode screenshot](http://central.hoa-project.net/Resource/Contributions/Emacs/Pp/screenshots/sample.png?format=raw)
 


### PR DESCRIPTION
Imenu is an Emacs feature that allows a package to define the outline
of the buffer's content to let user navigate quickly in it.

This commit brings Imenu support to `hoa-pp-mode` by creating two
sections, "Tokens" and "Rules", that lets the user go quickly to the
token / rule definition of its choice.
